### PR TITLE
Fix compile, linting issues

### DIFF
--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -5,3 +5,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: arduino/arduino-lint-action@v1
+        with:
+          library-manager: update

--- a/src/ht16k33.cpp
+++ b/src/ht16k33.cpp
@@ -342,7 +342,7 @@ uint8_t HT16K33::set16Seg(uint8_t dig, uint8_t cha){ // position 0-15, 0-15 (0-F
 // level 0-15, 0 means display off
 //
 uint8_t HT16K33::setBrightness(uint8_t level){
-  if (level >= HT16K33_DIM_1 && level <HT16K33_DIM_16){
+  if (level<HT16K33_DIM_16){
     return i2c_write(HT16K33_DIM|level);
   } else {
     return 1;


### PR DESCRIPTION
This corrects the linter error by specifying that further pushes/PRs will be used to update the existing library in the Library Manager, and also corrects the newly-reintroduced compiler error in SetBrightness.

This compiler error is because the constant HT16K33_DIM_1 is equal to 0, and since SetBrightness only accepts uint8_t as a data type it is not possible for the passed value to be less than 0. As such specifying `level >= HT16K33_DIM_1` is unnecessary and the cause of a compiler warning in the Arduino IDE.