### PR TITLE
Brightness fix, version update

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=simple ht16k33 library
-version=1.0.1
+version=1.0.2
 author=lpaseen
 maintainer=Peter Sjoberg <peters-alib AT techwiz.ca>
 sentence=Arduino library code for the htk1633 chip to do things like turn on LEDs or scan keys.

--- a/src/ht16k33.cpp
+++ b/src/ht16k33.cpp
@@ -25,7 +25,7 @@
  *             Added clearAll() function
  * 2023-09-11  Nomake Wan <nomake_wan AT yahoo.co.jp>
  *             Fix for compiler warnings in IDE
- * 2024-01-14  Nomake Wan <nomake wan AT yahoo.co.jp>
+ * 2024-01-14  Nomake Wan <nomake_wan AT yahoo.co.jp>
  *             Fix to allow full brightness in setBrightness() function
  *
  */
@@ -467,7 +467,7 @@ int8_t HT16K33::readKey(boolean clear){
       key+=13;
     } // if diff
   } // for i
-  return 0; //apperently no new key was pressed - old might still be held down, pass clear=true to see it
+  return 0; //apparently no new key was pressed - old might still be held down, pass clear=true to see it
 } // readKey
 
 /****************************************************************/

--- a/src/ht16k33.cpp
+++ b/src/ht16k33.cpp
@@ -19,14 +19,14 @@
  * 2015-10-04  Peter Sjoberg <peters-alib AT techwiz.ca>
  *             Created using https://www.arduino.cc/en/Hacking/LibraryTutorial and ht16k33 datasheet
  * 2015-11-25  Peter Sjoberg <peters-alib AT techwiz DOT ca>
- *	       first check in to github
+ *             first check in to github
  * 2016-08-09  René Wennekes <rene.wennekes AT gmail.com>
  *             Contribution of 7-segment & 16-segment display support
  *             Added clearAll() function
- *
- *
- *
- *
+ * 2023-09-11  Nomake Wan <nomake_wan AT yahoo.co.jp>
+ *             Fix for compiler warnings in IDE
+ * 2024-01-14  Nomake Wan <nomake wan AT yahoo.co.jp>
+ *             Fix to allow full brightness in setBrightness() function
  *
  */
 

--- a/src/ht16k33.cpp
+++ b/src/ht16k33.cpp
@@ -342,7 +342,7 @@ uint8_t HT16K33::set16Seg(uint8_t dig, uint8_t cha){ // position 0-15, 0-15 (0-F
 // level 0-15, 0 means display off
 //
 uint8_t HT16K33::setBrightness(uint8_t level){
-  if (level<HT16K33_DIM_16){
+  if (level<=HT16K33_DIM_16){
     return i2c_write(HT16K33_DIM|level);
   } else {
     return 1;

--- a/src/ht16k33.h
+++ b/src/ht16k33.h
@@ -58,7 +58,7 @@ class HT16K33
   uint8_t set16Seg(uint8_t dig, uint8_t cha); // position 0-7, see asciifont.h
   boolean getLed(uint8_t ledno,boolean Fresh=false); // check if a specific led is on(true) or off(false)
   uint8_t setDisplayRaw(uint8_t pos, uint8_t val); // load byte "pos" with value "val"
-  uint8_t sendLed(); // send whatever led patter you set
+  uint8_t sendLed(); // send whatever led pattern you set
   uint8_t set7SegNow(uint8_t dig, uint8_t cha, boolean dp); // position 0-15, 0-15 (0-F Hexadecimal), decimal point and send led in one function
   uint8_t set7SegRaw(uint8_t dig, uint8_t val); // load byte "pos" with value "val"
   uint8_t set16SegNow(uint8_t dig, uint8_t cha); // position 0-17, see asciifont.h and send led in one function


### PR DESCRIPTION
This fixes the bug noticed by user stef-ladefense in #10 where setBrightness could never actually set the brightness level to maximum. It also updates the library.properties file to refer to version 1.0.2 so that the Arduino Library Manager can receive these fixes as well.

If this gets merged, I would humbly request that a new tag for 1.0.2 be created to complete the automated update process for the Arduino Library Manager.

Thank you!